### PR TITLE
Update on script and newly generated pac files

### DIFF
--- a/accamsterdamumc_worldwide.pac
+++ b/accamsterdamumc_worldwide.pac
@@ -1,0 +1,106 @@
+// This pac file contains data from the Worldwide instance for serviceArea O365Default version 2025073100
+// This PAC file will provide proxy config to Microsoft 365 services
+//  using data from the public web service for all endpoints
+function FindProxyForURL(url, host)
+{
+    var direct = "DIRECT";
+    var proxyServer = "PROXY 127.0.0.2:8080";
+
+        host = host.toLowerCase();
+    // Local/intranet bypass
+    if (host == "localhost" || shExpMatch(host, "127.*") || isPlainHostName(host)) {
+        return "DIRECT";
+    }
+
+    // Custom override domains
+    if (
+        shExpMatch(host, "*.githubusercontent.com") ||
+        shExpMatch(host, "*.azure.com") ||
+        shExpMatch(host, "*.azure.net") ||
+        shExpMatch(host, "*.microsoft.com") ||
+        shExpMatch(host, "*.windowsupdate.com") ||
+        shExpMatch(host, "*.microsoftonline.com") ||
+        shExpMatch(host, "*.microsoftonline.cn") ||
+        shExpMatch(host, "*.windows.net") ||
+        shExpMatch(host, "*.windowsazure.com") ||
+        shExpMatch(host, "*.windowsazure.cn") ||
+        shExpMatch(host, "*.azure.cn") ||
+        shExpMatch(host, "*.loganalytics.io") ||
+        shExpMatch(host, "*.applicationinsights.io") ||
+        shExpMatch(host, "*.vsassets.io") ||
+        shExpMatch(host, "*.azure-automation.net") ||
+        shExpMatch(host, "*.visualstudio.com") ||
+        shExpMatch(host, "portal.office.com") ||
+        shExpMatch(host, "*.aspnetcdn.com") ||
+        shExpMatch(host, "*.sharepointonline.com") ||
+        shExpMatch(host, "*.msecnd.net") ||
+        shExpMatch(host, "*.msocdn.com") ||
+        shExpMatch(host, "*.webtrends.com") ||
+        shExpMatch(host, "amsterdamumc.secretservercloud.eu") ||
+        shExpMatch(host, "*.surfconext.nl")
+    ) {
+        return "DIRECT";
+    }
+
+
+    if(shExpMatch(host, "cdn.odc.officeapps.live.com")
+        || shExpMatch(host, "cdn.uci.officeapps.live.com"))
+    {
+        return proxyServer;
+    }
+
+    if(shExpMatch(host, "*.auth.microsoft.com")
+        || shExpMatch(host, "*.lync.com")
+        || shExpMatch(host, "*.mail.protection.outlook.com")
+        || shExpMatch(host, "*.msftidentity.com")
+        || shExpMatch(host, "*.msidentity.com")
+        || shExpMatch(host, "*.mx.microsoft")
+        || shExpMatch(host, "*.officeapps.live.com")
+        || shExpMatch(host, "*.online.office.com")
+        || shExpMatch(host, "*.protection.office.com")
+        || shExpMatch(host, "*.protection.outlook.com")
+        || shExpMatch(host, "*.security.microsoft.com")
+        || shExpMatch(host, "*.sharepoint.com")
+        || shExpMatch(host, "*.teams.cloud.microsoft")
+        || shExpMatch(host, "*.teams.microsoft.com")
+        || shExpMatch(host, "account.activedirectory.windowsazure.com")
+        || shExpMatch(host, "accounts.accesscontrol.windows.net")
+        || shExpMatch(host, "adminwebservice.microsoftonline.com")
+        || shExpMatch(host, "api.passwordreset.microsoftonline.com")
+        || shExpMatch(host, "autologon.microsoftazuread-sso.com")
+        || shExpMatch(host, "becws.microsoftonline.com")
+        || shExpMatch(host, "ccs.login.microsoftonline.com")
+        || shExpMatch(host, "clientconfig.microsoftonline-p.net")
+        || shExpMatch(host, "companymanager.microsoftonline.com")
+        || shExpMatch(host, "compliance.microsoft.com")
+        || shExpMatch(host, "defender.microsoft.com")
+        || shExpMatch(host, "device.login.microsoftonline.com")
+        || shExpMatch(host, "graph.microsoft.com")
+        || shExpMatch(host, "graph.windows.net")
+        || shExpMatch(host, "login-us.microsoftonline.com")
+        || shExpMatch(host, "login.microsoft.com")
+        || shExpMatch(host, "login.microsoftonline-p.com")
+        || shExpMatch(host, "login.microsoftonline.com")
+        || shExpMatch(host, "login.windows.net")
+        || shExpMatch(host, "logincert.microsoftonline.com")
+        || shExpMatch(host, "loginex.microsoftonline.com")
+        || shExpMatch(host, "nexus.microsoftonline-p.com")
+        || shExpMatch(host, "office.live.com")
+        || shExpMatch(host, "outlook.cloud.microsoft")
+        || shExpMatch(host, "outlook.office.com")
+        || shExpMatch(host, "outlook.office365.com")
+        || shExpMatch(host, "passwordreset.microsoftonline.com")
+        || shExpMatch(host, "protection.office.com")
+        || shExpMatch(host, "provisioningapi.microsoftonline.com")
+        || shExpMatch(host, "purview.microsoft.com")
+        || shExpMatch(host, "security.microsoft.com")
+        || shExpMatch(host, "smtp.office365.com")
+        || shExpMatch(host, "teams.cloud.microsoft")
+        || shExpMatch(host, "teams.microsoft.com"))
+    {
+        return direct;
+    }
+
+    return proxyServer;
+}
+

--- a/amsterdamumc_worldwide.pac
+++ b/amsterdamumc_worldwide.pac
@@ -1,0 +1,106 @@
+// This pac file contains data from the Worldwide instance for serviceArea O365Default version 2025073100
+// This PAC file will provide proxy config to Microsoft 365 services
+//  using data from the public web service for all endpoints
+function FindProxyForURL(url, host)
+{
+    var direct = "DIRECT";
+    var proxyServer = "PROXY 127.0.0.2:8080";
+
+        host = host.toLowerCase();
+    // Local/intranet bypass
+    if (host == "localhost" || shExpMatch(host, "127.*") || isPlainHostName(host)) {
+        return "DIRECT";
+    }
+
+    // Custom override domains
+    if (
+        shExpMatch(host, "*.githubusercontent.com") ||
+        shExpMatch(host, "*.azure.com") ||
+        shExpMatch(host, "*.azure.net") ||
+        shExpMatch(host, "*.microsoft.com") ||
+        shExpMatch(host, "*.windowsupdate.com") ||
+        shExpMatch(host, "*.microsoftonline.com") ||
+        shExpMatch(host, "*.microsoftonline.cn") ||
+        shExpMatch(host, "*.windows.net") ||
+        shExpMatch(host, "*.windowsazure.com") ||
+        shExpMatch(host, "*.windowsazure.cn") ||
+        shExpMatch(host, "*.azure.cn") ||
+        shExpMatch(host, "*.loganalytics.io") ||
+        shExpMatch(host, "*.applicationinsights.io") ||
+        shExpMatch(host, "*.vsassets.io") ||
+        shExpMatch(host, "*.azure-automation.net") ||
+        shExpMatch(host, "*.visualstudio.com") ||
+        shExpMatch(host, "portal.office.com") ||
+        shExpMatch(host, "*.aspnetcdn.com") ||
+        shExpMatch(host, "*.sharepointonline.com") ||
+        shExpMatch(host, "*.msecnd.net") ||
+        shExpMatch(host, "*.msocdn.com") ||
+        shExpMatch(host, "*.webtrends.com") ||
+        shExpMatch(host, "amsterdamumc.secretservercloud.eu") ||
+        shExpMatch(host, "*.surfconext.nl")
+    ) {
+        return "DIRECT";
+    }
+
+
+    if(shExpMatch(host, "cdn.odc.officeapps.live.com")
+        || shExpMatch(host, "cdn.uci.officeapps.live.com"))
+    {
+        return proxyServer;
+    }
+
+    if(shExpMatch(host, "*.auth.microsoft.com")
+        || shExpMatch(host, "*.lync.com")
+        || shExpMatch(host, "*.mail.protection.outlook.com")
+        || shExpMatch(host, "*.msftidentity.com")
+        || shExpMatch(host, "*.msidentity.com")
+        || shExpMatch(host, "*.mx.microsoft")
+        || shExpMatch(host, "*.officeapps.live.com")
+        || shExpMatch(host, "*.online.office.com")
+        || shExpMatch(host, "*.protection.office.com")
+        || shExpMatch(host, "*.protection.outlook.com")
+        || shExpMatch(host, "*.security.microsoft.com")
+        || shExpMatch(host, "*.sharepoint.com")
+        || shExpMatch(host, "*.teams.cloud.microsoft")
+        || shExpMatch(host, "*.teams.microsoft.com")
+        || shExpMatch(host, "account.activedirectory.windowsazure.com")
+        || shExpMatch(host, "accounts.accesscontrol.windows.net")
+        || shExpMatch(host, "adminwebservice.microsoftonline.com")
+        || shExpMatch(host, "api.passwordreset.microsoftonline.com")
+        || shExpMatch(host, "autologon.microsoftazuread-sso.com")
+        || shExpMatch(host, "becws.microsoftonline.com")
+        || shExpMatch(host, "ccs.login.microsoftonline.com")
+        || shExpMatch(host, "clientconfig.microsoftonline-p.net")
+        || shExpMatch(host, "companymanager.microsoftonline.com")
+        || shExpMatch(host, "compliance.microsoft.com")
+        || shExpMatch(host, "defender.microsoft.com")
+        || shExpMatch(host, "device.login.microsoftonline.com")
+        || shExpMatch(host, "graph.microsoft.com")
+        || shExpMatch(host, "graph.windows.net")
+        || shExpMatch(host, "login-us.microsoftonline.com")
+        || shExpMatch(host, "login.microsoft.com")
+        || shExpMatch(host, "login.microsoftonline-p.com")
+        || shExpMatch(host, "login.microsoftonline.com")
+        || shExpMatch(host, "login.windows.net")
+        || shExpMatch(host, "logincert.microsoftonline.com")
+        || shExpMatch(host, "loginex.microsoftonline.com")
+        || shExpMatch(host, "nexus.microsoftonline-p.com")
+        || shExpMatch(host, "office.live.com")
+        || shExpMatch(host, "outlook.cloud.microsoft")
+        || shExpMatch(host, "outlook.office.com")
+        || shExpMatch(host, "outlook.office365.com")
+        || shExpMatch(host, "passwordreset.microsoftonline.com")
+        || shExpMatch(host, "protection.office.com")
+        || shExpMatch(host, "provisioningapi.microsoftonline.com")
+        || shExpMatch(host, "purview.microsoft.com")
+        || shExpMatch(host, "security.microsoft.com")
+        || shExpMatch(host, "smtp.office365.com")
+        || shExpMatch(host, "teams.cloud.microsoft")
+        || shExpMatch(host, "teams.microsoft.com"))
+    {
+        return direct;
+    }
+
+    return proxyServer;
+}
+

--- a/devamsterdamumc_worldwide.pac
+++ b/devamsterdamumc_worldwide.pac
@@ -1,0 +1,106 @@
+// This pac file contains data from the Worldwide instance for serviceArea O365Default version 2025073100
+// This PAC file will provide proxy config to Microsoft 365 services
+//  using data from the public web service for all endpoints
+function FindProxyForURL(url, host)
+{
+    var direct = "DIRECT";
+    var proxyServer = "PROXY 127.0.0.2:8080";
+
+        host = host.toLowerCase();
+    // Local/intranet bypass
+    if (host == "localhost" || shExpMatch(host, "127.*") || isPlainHostName(host)) {
+        return "DIRECT";
+    }
+
+    // Custom override domains
+    if (
+        shExpMatch(host, "*.githubusercontent.com") ||
+        shExpMatch(host, "*.azure.com") ||
+        shExpMatch(host, "*.azure.net") ||
+        shExpMatch(host, "*.microsoft.com") ||
+        shExpMatch(host, "*.windowsupdate.com") ||
+        shExpMatch(host, "*.microsoftonline.com") ||
+        shExpMatch(host, "*.microsoftonline.cn") ||
+        shExpMatch(host, "*.windows.net") ||
+        shExpMatch(host, "*.windowsazure.com") ||
+        shExpMatch(host, "*.windowsazure.cn") ||
+        shExpMatch(host, "*.azure.cn") ||
+        shExpMatch(host, "*.loganalytics.io") ||
+        shExpMatch(host, "*.applicationinsights.io") ||
+        shExpMatch(host, "*.vsassets.io") ||
+        shExpMatch(host, "*.azure-automation.net") ||
+        shExpMatch(host, "*.visualstudio.com") ||
+        shExpMatch(host, "portal.office.com") ||
+        shExpMatch(host, "*.aspnetcdn.com") ||
+        shExpMatch(host, "*.sharepointonline.com") ||
+        shExpMatch(host, "*.msecnd.net") ||
+        shExpMatch(host, "*.msocdn.com") ||
+        shExpMatch(host, "*.webtrends.com") ||
+        shExpMatch(host, "amsterdamumc.secretservercloud.eu") ||
+        shExpMatch(host, "*.surfconext.nl")
+    ) {
+        return "DIRECT";
+    }
+
+
+    if(shExpMatch(host, "cdn.odc.officeapps.live.com")
+        || shExpMatch(host, "cdn.uci.officeapps.live.com"))
+    {
+        return proxyServer;
+    }
+
+    if(shExpMatch(host, "*.auth.microsoft.com")
+        || shExpMatch(host, "*.lync.com")
+        || shExpMatch(host, "*.mail.protection.outlook.com")
+        || shExpMatch(host, "*.msftidentity.com")
+        || shExpMatch(host, "*.msidentity.com")
+        || shExpMatch(host, "*.mx.microsoft")
+        || shExpMatch(host, "*.officeapps.live.com")
+        || shExpMatch(host, "*.online.office.com")
+        || shExpMatch(host, "*.protection.office.com")
+        || shExpMatch(host, "*.protection.outlook.com")
+        || shExpMatch(host, "*.security.microsoft.com")
+        || shExpMatch(host, "*.sharepoint.com")
+        || shExpMatch(host, "*.teams.cloud.microsoft")
+        || shExpMatch(host, "*.teams.microsoft.com")
+        || shExpMatch(host, "account.activedirectory.windowsazure.com")
+        || shExpMatch(host, "accounts.accesscontrol.windows.net")
+        || shExpMatch(host, "adminwebservice.microsoftonline.com")
+        || shExpMatch(host, "api.passwordreset.microsoftonline.com")
+        || shExpMatch(host, "autologon.microsoftazuread-sso.com")
+        || shExpMatch(host, "becws.microsoftonline.com")
+        || shExpMatch(host, "ccs.login.microsoftonline.com")
+        || shExpMatch(host, "clientconfig.microsoftonline-p.net")
+        || shExpMatch(host, "companymanager.microsoftonline.com")
+        || shExpMatch(host, "compliance.microsoft.com")
+        || shExpMatch(host, "defender.microsoft.com")
+        || shExpMatch(host, "device.login.microsoftonline.com")
+        || shExpMatch(host, "graph.microsoft.com")
+        || shExpMatch(host, "graph.windows.net")
+        || shExpMatch(host, "login-us.microsoftonline.com")
+        || shExpMatch(host, "login.microsoft.com")
+        || shExpMatch(host, "login.microsoftonline-p.com")
+        || shExpMatch(host, "login.microsoftonline.com")
+        || shExpMatch(host, "login.windows.net")
+        || shExpMatch(host, "logincert.microsoftonline.com")
+        || shExpMatch(host, "loginex.microsoftonline.com")
+        || shExpMatch(host, "nexus.microsoftonline-p.com")
+        || shExpMatch(host, "office.live.com")
+        || shExpMatch(host, "outlook.cloud.microsoft")
+        || shExpMatch(host, "outlook.office.com")
+        || shExpMatch(host, "outlook.office365.com")
+        || shExpMatch(host, "passwordreset.microsoftonline.com")
+        || shExpMatch(host, "protection.office.com")
+        || shExpMatch(host, "provisioningapi.microsoftonline.com")
+        || shExpMatch(host, "purview.microsoft.com")
+        || shExpMatch(host, "security.microsoft.com")
+        || shExpMatch(host, "smtp.office365.com")
+        || shExpMatch(host, "teams.cloud.microsoft")
+        || shExpMatch(host, "teams.microsoft.com"))
+    {
+        return direct;
+    }
+
+    return proxyServer;
+}
+

--- a/proxy_pac_paw.ps1
+++ b/proxy_pac_paw.ps1
@@ -1,0 +1,109 @@
+[CmdletBinding()]
+param (
+    [ValidateSet("devamsterdamumc", "accamsterdamumc", "amsterdamumc")]
+    [Parameter(Mandatory = $true)]
+    [string] $TenantName
+)
+
+# Create new GUID to be used during requests
+$clientId = [guid]::NewGuid().ToString()
+
+# Set default proxy
+$defaultProxy = 'PROXY 127.0.0.2:8080'
+
+# Fetch Microsoft 365 endpoints of type 2 (Optimize + Allow traffic direct) 
+$opts = @{
+    Type = 2
+    Instance = 'Worldwide'
+    ClientRequestId = $clientId
+    DefaultProxySettings = $defaultProxy
+    TenantName = $TenantName
+    LowerCase = $true
+}
+
+# Load the Get-PacFile script (install if needed)
+if (-not (Get-InstalledScript Get-PacFile -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing Get-PacFile script from PSGallery..."
+    Install-Script -Name Get-PacFile -Scope CurrentUser -Force
+}
+# Get script location so we can call it. 
+$getPacCommand = (Join-Path (Get-InstalledScript -Name get-pacfile).InstalledLocation 'Get-Pacfile.ps1')
+
+# Get web service version info and prepend to the PAC file as a comment
+$ws = "https://endpoints.office.com"
+$version = Invoke-RestMethod -Uri ($ws + "/version/Worldwide?clientRequestId=" + $clientId)
+
+$filename = ("$($opts.TenantName)_$($opts.Instance).pac").ToLower()
+
+
+# Check the current version in the PAC file and compare it to the web service version
+if (Test-Path -PathType Leaf -Path $filename) {
+    Write-Host "Found existing PAC file at $($filename). Checking version..."
+    $pacHeader = Get-Content -Path $filename | Select-Object -First 1
+} else {
+    Write-Host "No existing PAC file found at $($filename). A new one will be created."
+    $pacHeader = ""
+}
+
+$pacVersion = $pacHeader -replace '.*version\s*([0-9]+).*','$1'
+
+$wsVersion = $version.latest
+
+if ($pacVersion -ne $wsVersion) {
+    Write-Warning "PAC file version ($pacVersion) does not match latest web service version ($wsVersion)."
+} else {
+    Write-Host "PAC file version matches web service version: $wsVersion. Expect no changes besides any custom domain overrides."
+}
+
+# Call Get-PacFile to retrieve the PAC contentß
+$pacContent = & $getPacCommand @opts
+
+# Append your custom override domains (ProxyOverride list)
+$customDomains = @(
+    "*.githubusercontent.com", "*.azure.com", "*.azure.net", "*.microsoft.com", "*.windowsupdate.com",
+    "*.microsoftonline.com", "*.microsoftonline.cn", "*.windows.net",
+    "*.windowsazure.com", "*.windowsazure.cn", "*.azure.cn",
+    "*.loganalytics.io", "*.applicationinsights.io", "*.vsassets.io",
+    "*.azure-automation.net", "*.visualstudio.com", "portal.office.com",
+    "*.aspnetcdn.com", "*.sharepointonline.com", "*.msecnd.net",
+    "*.msocdn.com", "*.webtrends.com", "amsterdamumc.secretservercloud.eu", "*.surfconext.nl"
+)
+
+# Build shExpMatch clauses
+$shClauses = ($customDomains | ForEach-Object { "shExpMatch(host, `"$($_)`")" }) -join " ||`n        "
+
+# Define constants for loopback, localhost, intranet
+$hostBypass = @"
+    // Local/intranet bypass
+    if (host == "localhost" || shExpMatch(host, "127.*") || isPlainHostName(host)) {
+        return "DIRECT";
+    }
+"@
+
+# Inject into PAC—wrap default direct-from-Get-PacFile logic
+$injection = @"
+    host = host.toLowerCase();
+$hostBypass
+
+    // Custom override domains
+    if (
+        $shClauses
+    ) {
+        return "DIRECT";
+    }
+
+"@
+
+# Replace the host normalization in pacContent to include the injection
+$pacText = $pacContent -replace 'host = host.toLowerCase\(\);', $injection
+
+# Output to file
+Set-Content -Path $filename -Value $pacText -Encoding UTF8
+
+# Append version info as comment at the top of the file
+Set-Content -Path $filename -Value ("// This pac file contains data from the $($version.instance) instance for serviceArea $($version.serviceArea) version $($version.latest)" + "`n" + (Get-Content $filename | Out-String))
+
+Write-Host "PAC file generated at: $filename"
+
+
+


### PR DESCRIPTION
…pac files

The script now contains a mandatory parameter for the tenantname. Also writing a header containing the version of the m365 endpoints web api version so we can keep track of that and check if newer endpoints should be expected. 

Generated additional pac files, now containing the tenant name and the used instance in the pac filename. Update used config in Intune to use the new pac file(s).